### PR TITLE
Upgrade Go versions 1.11-1.18 to v1.19

### DIFF
--- a/go/src/cmd/objdump/testdata/testfilenum/go.mod
+++ b/go/src/cmd/objdump/testdata/testfilenum/go.mod
@@ -1,3 +1,3 @@
 module cmd/objdump/testdata/testfilenum
 
-go 1.16
+go 1.19

--- a/grafana/pkg/util/xorm/go.mod
+++ b/grafana/pkg/util/xorm/go.mod
@@ -1,6 +1,6 @@
 module xorm.io/xorm
 
-go 1.11
+go 1.19
 
 require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4

--- a/sourcegraph/enterprise/dev/ci/images/go.mod
+++ b/sourcegraph/enterprise/dev/ci/images/go.mod
@@ -1,3 +1,3 @@
 module github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images
 
-go 1.14
+go 1.19

--- a/sourcegraph/enterprise/dev/insight-data-gen/go.mod
+++ b/sourcegraph/enterprise/dev/insight-data-gen/go.mod
@@ -1,6 +1,6 @@
 module insight-data-gen
 
-go 1.16
+go 1.19
 
 require (
 	github.com/cockroachdb/errors v1.8.6

--- a/sourcegraph/internal/cmd/progress-bot/go.mod
+++ b/sourcegraph/internal/cmd/progress-bot/go.mod
@@ -1,6 +1,6 @@
 module progress-bot
 
-go 1.16
+go 1.19
 
 require (
 	cloud.google.com/go/compute v1.1.0 // indirect


### PR DESCRIPTION
This batch change upgrades the outdated Go versions found in the codebase to v1.19

[_Created by Sourcegraph batch change `andrew.hsu/blabla`._](https://demo.sourcegraph.com/users/andrew.hsu/batch-changes/blabla)